### PR TITLE
Only lint file input once, via stdin

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter
 
 
 class Selene(Linter):
-    cmd = ('selene', '-', '${file}', '--display-style=quiet')
+    cmd = ('selene', '-', '--display-style=quiet')
     regex = (
         r'.+:(?P<line>\d+):(?P<col>\d+): '
         r'(?:warning\[(?P<warning>.+)|error\[(?P<error>.+))\]: '


### PR DESCRIPTION
Closes #1.

I noticed the same issue as @TeaSaves here, that errors pop up twice. Additionally, when there are unsaved edits, error markers from the same version of the file show up over the top of the new contents. Those errors are usually out of date.

This PR just applies their suggested fix. It works well in my local build.